### PR TITLE
makes  'evaluate' idempotent

### DIFF
--- a/lib/Validation/Class/Simple/Streamer.pm
+++ b/lib/Validation/Class/Simple/Streamer.pm
@@ -230,8 +230,6 @@ sub validate {
 
     my $true = $self->prototype->validate($self);
 
-    $self->prototype->clear_queue if $true; # reduces validation overhead
-
     return $true;
 
 }

--- a/t/03-streaming.t
+++ b/t/03-streaming.t
@@ -26,6 +26,7 @@ use warnings;
         if ($p1->max_length(50)) {
             $p1->filters(['alpha', 'trim', 'strip']);
             ok $p1, "p1 validated";
+            ok $p1, "p1 still validated";
         }
     }
 


### PR DESCRIPTION
Deals with #37. The optimization was making it such that calling `validate` a second time would cause a stack trace.